### PR TITLE
🐛 FIX: Day missing when selecting days in calendar

### DIFF
--- a/packages/ui/components/date-picker.tsx
+++ b/packages/ui/components/date-picker.tsx
@@ -72,7 +72,7 @@ const DatePicker = ({
             numberOfMonths={2}
             onDayPointerEnter={(day) => {
               if (daysFromDate && day >= daysFromDate) {
-                setHoveredDays(differenceInDays(day, daysFromDate) + 1);
+                setHoveredDays(differenceInDays(day, daysFromDate) + 2);
               } else {
                 setHoveredDays(undefined);
               }


### PR DESCRIPTION
Fixes #735